### PR TITLE
Move rule-checking to top of `get`

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ Cache.prototype.setDataCache = function(data) {
 
     if (Array.isArray(data[k])) {
       for (var o in data[k]) {
-        if (data[k][o].hasOwnProperty(id)) {
+        if (data[k][o].hasOwnProperty(id) && this.dataCache[k]) {
           this.dataCache[k].set(data[k][o][id], data[k][o]);
         }
       }

--- a/test/cache.js
+++ b/test/cache.js
@@ -175,6 +175,8 @@ describe('Cache', function() {
       }).then(function() {
         //try {
         expect(Cache.prototype.loadFromCache).to.not.have.been.called.once;
+        expect(cache.dataCache.objects).to.be.undefined;
+
         stub.restore();
         done();
         //}catch(e){console.log(e)}

--- a/test/cache.js
+++ b/test/cache.js
@@ -81,9 +81,9 @@ describe('Cache', function() {
     it('takes datatypes', function() {
       var dataTypes = {};
 
-      var cache = new Cache({
+      var cache = new Cache(Object.assign({
         dataTypes: dataTypes
-      });
+      }, config));
 
       expect(cache.dataTypes).to.equal(dataTypes);
     });
@@ -133,11 +133,7 @@ describe('Cache', function() {
     it('loads from cache on rule success', function(done) {
       var stub = sinon.stub(Cache.prototype, 'loadFromCache');
 
-      var cache = new Cache({
-        defaultRequestCacheConfig: {
-          cache: { max: 50 }
-        }
-      });
+      var cache = new Cache(config);
 
       cache.get(apiGET, [], {
         format: formatResponse,
@@ -157,15 +153,9 @@ describe('Cache', function() {
     });
 
     it('does not load from cache on rule failure', function(done) {
-      var defaultConfig = {
-        cache: { max: 50 }
-      };
-
       var stub = sinon.stub(Cache.prototype, 'loadFromCache');
 
-      var cache = new Cache({
-        config: defaultConfig,
-      });
+      var cache = new Cache(config);
 
       cache.get(apiGET, [], {
         format: formatResponse,
@@ -173,13 +163,11 @@ describe('Cache', function() {
           return false;
         }]
       }).then(function() {
-        //try {
         expect(Cache.prototype.loadFromCache).to.not.have.been.called.once;
         expect(cache.dataCache.objects).to.be.undefined;
 
         stub.restore();
         done();
-        //}catch(e){console.log(e)}
       }, function(e) {
         console.log(e.stack);
         stub.restore();


### PR DESCRIPTION
Check for failed rules before anything else, so we don't bother with the rest of the logic if we shouldn't be using the cache. This prevents the cache from being set on a rule failure; previously, it wouldn't attempt the load, but it _would_ attempt the cache set.

:eyeglasses: @curioussavage @spladug 
