### PR TITLE
Call promise immediately if no key/options supplied

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,10 @@ Cache.prototype.setUpDataCache = function() {
 Cache.prototype.get = function(fn, params, options) {
   var options = options || this.defaultRequestCacheConfig || {};
 
+  if (!options || !options.key) {
+    return fn.apply(undefined, params);
+  }
+
   if (options.rules) {
     var failedRule = options.rules.some(function(rule) {
       return !rule(params);
@@ -46,10 +50,6 @@ Cache.prototype.get = function(fn, params, options) {
 
   if (!options.cache && this.defaultRequestCacheConfig.cache) {
     options.cache = this.defaultRequestCacheConfig.cache;
-  }
-
-  if (!key) {
-    return Promise.reject('No key was passed in, and function did not have a name.');
   }
 
   var paramsHash = Cache.generateHash(params);


### PR DESCRIPTION
Make it easier to pass through the cache if we don't want to use default options _or_ pass in anything, rather than rejecting an error.

:eyeglasses: @curioussavage or @schwers 
